### PR TITLE
Revert duration hint to MAY_DUCK

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
+++ b/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
@@ -81,7 +81,7 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
     private final UtteranceProgressListener utteranceListener = new UtteranceProgressListener() {
         @Override
         public void onStart(String utteranceId) {
-            int result = audioManager.requestAudioFocus(audioFocusChangeListener, TextToSpeech.Engine.DEFAULT_STREAM, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
+            int result = audioManager.requestAudioFocus(audioFocusChangeListener, TextToSpeech.Engine.DEFAULT_STREAM, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK);
             if (result == AudioManager.AUDIOFOCUS_REQUEST_FAILED) {
                 Log.w(TAG, "Failed to request audio focus.");
             }
@@ -89,7 +89,7 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
 
         @Override
         public void onDone(String utteranceId) {
-            int result = audioManager.abandonAudioFocus(null);
+            int result = audioManager.abandonAudioFocus(audioFocusChangeListener);
             if (result == AudioManager.AUDIOFOCUS_REQUEST_FAILED) {
                 Log.w(TAG, "Failed to relinquish audio focus.");
             }


### PR DESCRIPTION
Revert the duration hint passed to `requestAudioFocus` to `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` and pass `audioFocusChangeListener` to `abandonAudioFocus`.

Starting the following commit: https://github.com/dennisguse/OpenTracks/commit/d1a459efc2417d6c0bf3490459228ec4b19fff1b the duration hint was changed from `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` to `AUDIOFOCUS_GAIN_TRANSIENT`.
This introduced the behavior that OpenTracks stops audio players when doing the voice announcement, after the announcement was finished the audio player however didn't resume playing and required manual intervention.

IMO the voice announcement shouldn't stop your music since it is annoying and definitely against what the user expects. Ducking the volume, as it was < `v3.2.9`, is the better option.

(In my case - using Amazon Music - I had to press pause and play again to resume the audio. The play/pause button on the BT headset I use didn't work so I had to pull out the device and do it on screen.)

I assume this behavior is due to the `null` that was passed to `abandonAudioFocus`. That's why we should pass the `audioFocusChangeListener` as described in the AudioManager reference: https://developer.android.com/reference/android/media/AudioManager.html#abandonAudioFocus(android.media.AudioManager.OnAudioFocusChangeListener)

Can't test this change before I get home. Feel free give it no priority.